### PR TITLE
Wrap text tags in g tag

### DIFF
--- a/src/utils/getSvg.tsx
+++ b/src/utils/getSvg.tsx
@@ -128,9 +128,13 @@ export const getSuccessSvg = (info: SvgInfo): string => {
         <g transform="translate(400, 47.5)">
           <circle class="acceptance-circle-rim" cx="-10" cy="8" r="60" />
           <circle class="acceptance-circle" cx="-10" cy="8" r="60" />
-          <text class="acceptance-text" x="0" y="0" alignment-baseline="central" dominant-baseline="central" text-anchor="middle"> ${acceptanceRate}% </text>
-          <text class="acceptance-title" x="0" y="20" alignment-baseline="central" dominant-baseline="central" text-anchor="middle"> acceptance </text>
+          <g class="acceptance-text" xmlns="http://www.w3.org/2000/svg">
+            <text x="0" y="0" alignment-baseline="central" dominant-baseline="central" text-anchor="middle"> ${acceptanceRate}% </text>
           </g>
+          <g class="acceptance-title" xmlns="http://www.w3.org/2000/svg">
+            <text  x="0" y="20" alignment-baseline="central" dominant-baseline="central" text-anchor="middle"> acceptance </text>
+          </g>
+        </g>
         <svg x="0" y="0">
           <g transform="translate(0, 0)">
             <g class="stagger" style="animation-delay: 450ms" transform="translate(25, 0)">


### PR DESCRIPTION
Related to issue: https://github.com/JeremyTsaii/leetcode-stats/issues/5

Wrapping text tag in g tag and add class on g tag makes Safari more SVG compliant. Trail and error kinda proved it, while this stackoverflow helped me achieve the solution, https://stackoverflow.com/questions/65685528/svg-text-doesnt-render-on-safari-but-renders-on-chrome